### PR TITLE
Decoupled blocks should add their framework and settings using #attached

### DIFF
--- a/modules/pdb_ng2/assets/app/app.ts
+++ b/modules/pdb_ng2/assets/app/app.ts
@@ -3,8 +3,8 @@ import {bootstrap, BROWSER_PROVIDERS, BROWSER_APP_PROVIDERS} from 'angular2/plat
 
 import 'rxjs/add/operator/map';
 
-import {ScrollLoader} from 'modules/pdb/modules/pdb_ng2/assets/classes/scroll-loader.ts';
-import {GlobalProviders} from 'modules/pdb/modules/pdb_ng2/assets/classes/global-providers.ts';
+import {ScrollLoader} from '../classes/scroll-loader.ts';
+import {GlobalProviders} from '../classes/global-providers.ts';
 
 var injectables = drupalSettings.ng2.global_injectables;
 var globalProviders = new GlobalProviders(injectables);

--- a/modules/pdb_ng2/assets/app/systemConfig.js
+++ b/modules/pdb_ng2/assets/app/systemConfig.js
@@ -7,7 +7,7 @@ System.config({
   },
   //map tells the System loader where to look for things
   map: {
-    app: 'modules/pdb/modules/pdb_ng2/assets/app'
+    app: '/modules/pdb/modules/pdb_ng2/assets/app'
   },
   //packages defines our app package
   packages: {

--- a/modules/pdb_ng2/src/EventSubscriber/Block/SettingSubscriber.php
+++ b/modules/pdb_ng2/src/EventSubscriber/Block/SettingSubscriber.php
@@ -27,7 +27,7 @@ class SettingSubscriber implements EventSubscriberInterface {
         $settings['apps'] = array();
       }
       $settings['apps'][$info['machine_name']] = array(
-        'uri' => '/' . $info['path']
+        'uri' => '/' . $info['path'],
       );
     }
 

--- a/modules/pdb_ng2/src/EventSubscriber/Framework/InitializeSubscriber.php
+++ b/modules/pdb_ng2/src/EventSubscriber/Framework/InitializeSubscriber.php
@@ -22,45 +22,25 @@ class InitializeSubscriber implements EventSubscriberInterface {
   public function onFrameworkInitialize(InitializeEvent $event) {
     $variant_blocks = $event->getControllerResult();
 
-    // TODO: We still need a way to decide if the entire
-    // page supports angular2 components but this should be
-    // part of the framework compatibility work.
-    $pdb_block_deriver     = new PdbBlockDeriver('component_block');
-    $pdb_block_definitions = $pdb_block_deriver->getDerivativeDefinitions();
-    $components = array();
+    $settings = array(
+      'ng2' => array(
+        'global_injectables' => array(),
+        'components' => array(),
+      ),
+    );
 
     foreach ($variant_blocks as $block_uuid => $block) {
-      $block_name       = str_replace('component_block:', '', $block['id']);
-      $block_definition = $pdb_block_definitions[$block_name];
-
-      if ($block_definition['info']['presentation'] === 'ng2') {
-        $module_uri_array = explode('/', $block_definition['info']['path']);
-        array_pop($module_uri_array);
-
-        $component_root = '/' . implode('/', $module_uri_array);
-        $selector       = 'instance-id-' . $block_uuid;
-
-        $components[$selector] = array(
-          'uuid'           => $block_uuid,
-          'uri'            => '/' . $block_definition['info']['path'],
-          'component_root' => $component_root,
-          'element'        => $block_name,
-        );
+      if ($block['info']['presentation'] === 'ng2') {
+        $settings['ng2']['components']['instance-id-' . $block_uuid] = [
+          'uri' => '/' . $block['info']['path'],
+          'element' => $block['info']['machine_name'],
+        ];
       }
     }
 
-    if (!empty($components)) {
-      // Add the angular2 components to the drupalSettings array.
-      $drupalSettings = $event->getDrupalSettings();
-      $drupalSettings += array(
-        'ng2' => array(
-          'global_injectables' => array(),
-          'components' => $components,
-        ),
-      );
-
-      $event->setDrupalSettings($drupalSettings);
-    }
+    $drupalSettings = $event->getDrupalSettings();
+    $drupalSettings += $settings;
+    $event->setDrupalSettings($drupalSettings);
   }
 
   /**


### PR DESCRIPTION
As discussed on Wednesday with @tedbow, it makes a lot of sense for decoupled blocks to add their framework and settings to the page in their #attached array, rather than using the event system to add those things.

This PR is an intermediate fix -- it uses the event system to build an #attached array for a decoupled block as it's built.