### PR TITLE
8.x 1 context js - serialize entities in drupalSettings

### DIFF
--- a/src/Plugin/Block/PdbBlock.php
+++ b/src/Plugin/Block/PdbBlock.php
@@ -22,9 +22,17 @@ abstract class PdbBlock extends BlockBase implements FrameworkAwareBlockInterfac
    */
   protected $serializer;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, Serializer $serializer = NULL) {
+  /**
+   * PdbBlock constructor.
+   *
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   * @param \Symfony\Component\Serializer\Serializer $serializer
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, Serializer $serializer) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->serializer = \Drupal::service('serializer');
+    $this->serializer = $serializer;
   }
 
   /**
@@ -152,6 +160,8 @@ abstract class PdbBlock extends BlockBase implements FrameworkAwareBlockInterfac
   }
 
   /**
+   * Add serialized entity to the JS Contexts.
+   *
    * @param \Drupal\Core\Entity\Plugin\DataType\EntityAdapter $data
    * @param array $js_contexts
    * @param $key
@@ -171,7 +181,7 @@ abstract class PdbBlock extends BlockBase implements FrameworkAwareBlockInterfac
         $entity->set($field_name, NULL);
       }
     }
-    /** @todo Serialize*/
+    // Serialize the entity.
     $serialized_entity = $this->serializer->serialize($entity, 'json');
     $js_contexts["$key:" . $entity->getEntityTypeId()] = $serialized_entity;
   }
@@ -179,7 +189,7 @@ abstract class PdbBlock extends BlockBase implements FrameworkAwareBlockInterfac
   /**
    * Get an array of serilized JS contexts.
    *
-   * @param ContextInterface[] $contexts
+   * @param \Drupal\Component\Plugin\Context\ContextInterface[] $contexts
    */
   protected function getJSContexts(array $contexts) {
     $js_contexts = [];

--- a/src/Plugin/Block/PdbBlock.php
+++ b/src/Plugin/Block/PdbBlock.php
@@ -10,29 +10,27 @@ namespace Drupal\pdb\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\pdb\FrameworkAwareBlockInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Serializer\Serializer;
 
-abstract class PdbBlock extends BlockBase implements FrameworkAwareBlockInterface {
-
-  /**
-   * @var \Drupal\Core\Render\RendererInterface
-   */
-  protected $renderer;
+abstract class PdbBlock extends BlockBase implements FrameworkAwareBlockInterface, ContainerFactoryPluginInterface {
 
   /**
    * @var \Symfony\Component\Serializer\Serializer
    */
   protected $serializer;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, Serializer $serializer) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, Serializer $serializer = NULL) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->serializer = $serializer;
+    $this->serializer = \Drupal::service('serializer');
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-
     return new static(
       $configuration,
       $plugin_id,
@@ -40,6 +38,7 @@ abstract class PdbBlock extends BlockBase implements FrameworkAwareBlockInterfac
       $container->get('serializer')
     );
   }
+
   /**
    * {@inheritdoc}
    */
@@ -173,7 +172,8 @@ abstract class PdbBlock extends BlockBase implements FrameworkAwareBlockInterfac
       }
     }
     /** @todo Serialize*/
-    $js_contexts["$key:" . $entity->getEntityTypeId()] = $entity;
+    $serialized_entity = $this->serializer->serialize($entity, 'json');
+    $js_contexts["$key:" . $entity->getEntityTypeId()] = $serialized_entity;
   }
 
   /**


### PR DESCRIPTION
Serializing the entity context into drupalSettings.pdb.contexts

Not retrieving on client side in any way