### PR TITLE
Create a component discovery service

### DIFF
--- a/pdb.services.yml
+++ b/pdb.services.yml
@@ -1,0 +1,7 @@
+services:
+  pdb.component_discovery:
+    class: '\Drupal\pdb\ComponentDiscovery'
+    arguments:
+      - '@app.root'
+      - '@module_handler'
+      - '@info_parser'

--- a/src/ComponentDiscovery.php
+++ b/src/ComponentDiscovery.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\pdb\ComponentDiscovery.
+ */
+
+namespace Drupal\pdb;
+
+use Drupal\Core\Extension\ExtensionDiscovery;
+use Drupal\Core\Extension\InfoParserInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+class ComponentDiscovery extends ExtensionDiscovery implements ComponentDiscoveryInterface {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The info parser.
+   *
+   * @var \Drupal\Core\Extension\InfoParserInterface
+   */
+  protected $infoParser;
+
+  /**
+   * ComponentDiscovery constructor.
+   *
+   * @param string $root
+   *   The root directory of the Drupal installation.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\Extension\InfoParserInterface $info_parser
+   *   The info parser.
+   */
+  public function __construct($root, ModuleHandlerInterface $module_handler, InfoParserInterface $info_parser) {
+    parent::__construct($root);
+    $this->moduleHandler = $module_handler;
+    $this->infoParser = $info_parser;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getComponents() {
+    // Find components.
+    $components = $this->scan('pdb');
+
+    // Set defaults for module info.
+    $defaults = array(
+      'dependencies' => array(),
+      'description' => '',
+      'package' => 'Other',
+      'version' => NULL,
+    );
+
+    // Read info files for each module.
+    foreach ($components as $key => $component) {
+      // Look for the info file.
+      $component->info = $this->infoParser->parse($component->getPathname());
+      $component->info['path'] = $component->origin . '/' . $component->subpath;
+
+      // Merge in defaults and save.
+      $components[$key]->info = $component->info + $defaults;
+    }
+    $this->moduleHandler->alter('component_info', $components);
+
+    return $components;
+  }
+
+}

--- a/src/ComponentDiscoveryInterface.php
+++ b/src/ComponentDiscoveryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\pdb\ComponentDiscoveryInterface.
+ */
+
+namespace Drupal\pdb;
+
+interface ComponentDiscoveryInterface {
+
+  public function getComponents();
+
+}

--- a/src/Plugin/Derivative/PdbBlockDeriver.php
+++ b/src/Plugin/Derivative/PdbBlockDeriver.php
@@ -8,11 +8,11 @@
 namespace Drupal\pdb\Plugin\Derivative;
 
 use Drupal\Component\Plugin\Derivative\DeriverBase;
-use Drupal\Core\Extension\ExtensionDiscovery;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Drupal\pdb\ComponentDiscoveryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -21,30 +21,20 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class PdbBlockDeriver extends DeriverBase implements ContainerDeriverInterface {
 
   /**
-   * The module handler.
+   * The component discovery service.
    *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   * @var \Drupal\pdb\ComponentDiscoveryInterface
    */
-  protected $moduleHandler;
-
-  /**
-   * The info parser.
-   *
-   * @var \Drupal\Core\Extension\InfoParserInterface
-   */
-  protected $infoParser;
+  protected $componentDiscovery;
 
   /**
    * PdbBlockDeriver constructor.
    *
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   * @param \Drupal\Core\Extension\InfoParserInterface $info_parser
-   *   The info parser.
+   * @param \Drupal\pdb\ComponentDiscoveryInterface $component_discovery
+   *   The component discovery service.
    */
-  public function __construct(ModuleHandlerInterface $module_handler, InfoParserInterface $info_parser) {
-    $this->moduleHandler = $module_handler;
-    $this->infoParser = $info_parser;
+  public function __construct(ComponentDiscoveryInterface $component_discovery, ModuleHandlerInterface $module_handler, InfoParserInterface $info_parser) {
+    $this->componentDiscovery = $component_discovery;
   }
 
   /**
@@ -52,8 +42,7 @@ class PdbBlockDeriver extends DeriverBase implements ContainerDeriverInterface {
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
     return new static(
-      $container->get('module_handler'),
-      $container->get('info_parser')
+      $container->get('pdb.component_discovery')
     );
   }
 
@@ -62,7 +51,7 @@ class PdbBlockDeriver extends DeriverBase implements ContainerDeriverInterface {
    */
   public function getDerivativeDefinitions($base_plugin_definition) {
     // Get all custom blocks which should be rediscovered.
-    $components = $this->getComponents();
+    $components = $this->componentDiscovery->getComponents();
     foreach ($components as $block_id => $block_info) {
       $this->derivatives[$block_id] = $base_plugin_definition;
       $this->derivatives[$block_id]['info'] = $block_info->info;
@@ -73,44 +62,6 @@ class PdbBlockDeriver extends DeriverBase implements ContainerDeriverInterface {
       }
     }
     return $this->derivatives;
-  }
-
-  /**
-   * Helper function to scan and collect component .info.yml data.
-   *
-   * This is based on system.module function _system_rebuild_module_data().
-   *
-   * @TODO: The results of this need to be cached.
-   *
-   * @return \Drupal\Core\Extension\Extension[]
-   *   An associative array of component information.
-   */
-  public function getComponents() {
-    $listing = new ExtensionDiscovery(\Drupal::root());
-
-    // Find components.
-    $components = $listing->scan('pdb');
-
-    // Set defaults for module info.
-    $defaults = array(
-      'dependencies' => array(),
-      'description' => '',
-      'package' => 'Other',
-      'version' => NULL,
-    );
-
-    // Read info files for each module.
-    foreach ($components as $key => $component) {
-      // Look for the info file.
-      $component->info = $this->infoParser->parse($component->getPathname());
-      $component->info['path'] = $component->origin . '/' . $component->subpath;
-
-      // Merge in defaults and save.
-      $components[$key]->info = $component->info + $defaults;
-    }
-    $this->moduleHandler->alter('component_info', $components);
-
-    return $components;
   }
 
   /**


### PR DESCRIPTION
The discovery stuff really doesn't belong in the PdbBlockDeriver -- the deriver is for generating block definitions, and component discovery is a separate task. This PR moves the discovery stuff into an injectable service conforming to a new ComponentDiscoveryInterface.