### PR TITLE
A stub NG2 upload component that exposes component-specific libraries

### DIFF
--- a/modules/pdb_ng2/assets/app/systemConfig.js
+++ b/modules/pdb_ng2/assets/app/systemConfig.js
@@ -1,21 +1,72 @@
-System.config({
-  //use typescript for compilation
-  transpiler: 'typescript',
-  //typescript compiler options
-  typescriptOptions: {
-    emitDecoratorMetadata: true
-  },
-  //map tells the System loader where to look for things
-  map: {
-    app: '/modules/pdb/modules/pdb_ng2/assets/app'
-  },
-  //packages defines our app package
-  packages: {
-    app: {
-      main: 'app',
-      defaultExtension: 'ts'
-    },
-    angular: { defaultExtension: false }
+(function (drupalSettings) {
+  "use strict";
+
+  // Source: http://gomakethings.com/vanilla-javascript-version-of-jquery-extend
+
+  // Pass in the objects to merge as arguments.
+  // For a deep extend, set the first argument to `true`.
+  function extend () {
+    // Variables
+    var extended = {};
+    var deep = false;
+    var i = 0;
+    var length = arguments.length;
+
+    // Check if a deep merge
+    if ( Object.prototype.toString.call( arguments[0] ) === '[object Boolean]' ) {
+      deep = arguments[0];
+      i++;
+    }
+
+    // Merge the object into the extended object
+    var merge = function (obj) {
+      for ( var prop in obj ) {
+        if ( Object.prototype.hasOwnProperty.call( obj, prop ) ) {
+          // If deep merge and property is an object, merge properties
+          if ( deep && Object.prototype.toString.call(obj[prop]) === '[object Object]' ) {
+            extended[prop] = extend( true, extended[prop], obj[prop] );
+          } else {
+            extended[prop] = obj[prop];
+          }
+        }
+      }
+    };
+
+    // Loop through each object and conduct a merge
+    for ( ; i < length; i++ ) {
+      var obj = arguments[i];
+      merge(obj);
+    }
+
+    return extended;
   }
-});
-System.import('app').catch(console.error.bind(console));
+
+  var config = {
+    //use typescript for compilation
+    transpiler: 'typescript',
+    //typescript compiler options
+    typescriptOptions: {
+      emitDecoratorMetadata: true
+    },
+    //map tells the System loader where to look for things
+    map: {
+      app: '/modules/pdb/modules/pdb_ng2/assets/app'
+    },
+    //packages defines our app package
+    packages: {
+      app: {
+        main: 'app',
+        defaultExtension: 'ts'
+      },
+      angular: { defaultExtension: false }
+    }
+  };
+
+  if ('SystemJS' in drupalSettings) {
+    config = extend(true, config, drupalSettings.SystemJS);
+  }
+
+  System.config(config);
+  System.import('app').catch(console.error.bind(console));
+
+})(drupalSettings);

--- a/modules/pdb_ng2/components/ng2_upload/component.ts
+++ b/modules/pdb_ng2/components/ng2_upload/component.ts
@@ -1,0 +1,17 @@
+import {Component} from 'angular2/core';
+import { FILE_UPLOAD_DIRECTIVES, FileUploader } from 'ng2-file-upload';
+
+@Component({
+  moduleId: __moduleName,
+  selector: 'ng2-upload'
+  templateUrl: 'template.html',
+  directives: [FILE_UPLOAD_DIRECTIVES]
+})
+export class Ng2Upload
+{
+  private uploader = new FileUploader({ url: '/upload' });
+
+  fileOver (event) {
+    console.log('A dragon is here');
+  }
+}

--- a/modules/pdb_ng2/components/ng2_upload/ng2_upload.info.yml
+++ b/modules/pdb_ng2/components/ng2_upload/ng2_upload.info.yml
@@ -1,0 +1,24 @@
+name: NG2 Upload
+machine_name: ng2-upload
+type: pdb
+description: 'NG 2 Upload'
+package: NG2
+version: '1.0.0'
+core: '8.x'
+module_status: active
+presentation: ng2
+settings:
+  SystemJS:
+    map:
+      ng2-file-upload: '/libraries/ng2-file-upload'
+    packages:
+      ng2-file-upload:
+        main: ng2-file-upload
+        defaultExtension: ts
+add_js:
+  header:
+  footer:
+add_css:
+  header:
+  footer:
+shared:

--- a/modules/pdb_ng2/components/ng2_upload/template.html
+++ b/modules/pdb_ng2/components/ng2_upload/template.html
@@ -1,0 +1,1 @@
+<div ng2-file-drop (fileOver)="fileOver($event)" [uploader]="uploader">Here be dragons</div>

--- a/modules/pdb_ng2/src/Plugin/Block/Ng2Block.php
+++ b/modules/pdb_ng2/src/Plugin/Block/Ng2Block.php
@@ -48,10 +48,11 @@ class Ng2Block extends PdbBlock {
    * {@inheritdoc}
    */
   public function attachSettings(array $component) {
+    $attached = parent::attachSettings($component);
+
     $machine_name = $component['machine_name'];
     $uuid = $this->configuration['uuid'];
 
-    $attached = array();
     $attached['drupalSettings']['ng2']['components']['instance-id-' . $uuid] = [
       'uri' => $component['path'],
       'element' => $machine_name,

--- a/src/Plugin/Block/PdbBlock.php
+++ b/src/Plugin/Block/PdbBlock.php
@@ -118,7 +118,14 @@ abstract class PdbBlock extends BlockBase implements FrameworkAwareBlockInterfac
    * {@inheritdoc}
    */
   public function attachSettings(array $component) {
-    return array();
+    if (isset($component['settings'])) {
+      return array(
+        'drupalSettings' => $component['settings'],
+      );
+    }
+    else {
+      return array();
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds a shell component to upload files with Angular 2, and it exposes a component-specific library that is loaded asynchronously using the ES6 module loading system (which means it needs to pass configuration into SystemJS). It's not perfect, but for now it's a solid way for components to bring in additional resources.

This stuff should eventually be moved into Component API.