### PR TITLE
#60 Setup module path dynamically

### DIFF
--- a/modules/pdb_ng2/assets/app/systemConfig.js
+++ b/modules/pdb_ng2/assets/app/systemConfig.js
@@ -41,6 +41,8 @@
     return extended;
   }
 
+  var modulePath = drupalSettings.path.baseUrl +
+      drupalSettings.pdb.ng2.module_path;
   var config = {
     // Use typescript for compilation.
     transpiler: 'typescript',
@@ -50,7 +52,7 @@
     },
     // Map tells the System loader where to look for things.
     map: {
-      app: '/modules/pdb/modules/pdb_ng2/assets/app'
+      app: modulePath + '/assets/app'
     },
     // Packages defines our app package.
     packages: {

--- a/modules/pdb_ng2/components/ng2_todo/component.ts
+++ b/modules/pdb_ng2/components/ng2_todo/component.ts
@@ -3,8 +3,8 @@ import {TodoStore, Todo} from './services/store.ts';
 
 @Component({
     selector: 'ng2-todo',
-    templateUrl: Drupal.url('modules/pdb/modules/pdb_ng2/components/ng2_todo/template.html'),
-    styleUrls: [Drupal.url('modules/pdb/modules/pdb_ng2/components/ng2_todo/style.css')],
+    templateUrl: Drupal.url(drupalSettings.pdb.ng2.module_path + '/components/ng2_todo/template.html'),
+    styleUrls: [Drupal.url(drupalSettings.pdb.ng2.module_path + '/components/ng2_todo/style.css')],
     providers: [TodoStore]
 })
 export class Ng2Todo {

--- a/modules/pdb_ng2/src/Plugin/Block/Ng2Block.php
+++ b/modules/pdb_ng2/src/Plugin/Block/Ng2Block.php
@@ -34,7 +34,7 @@ class Ng2Block extends PdbBlock {
    */
   public function attachFramework(array $component) {
     $attached = array();
-    $attached['drupalSettings']['pdb']['ng2']['global_injectables'] = array();
+    $attached['drupalSettings']['pdb']['ng2']['global_injectables'] = [];
 
     return $attached;
   }
@@ -52,6 +52,7 @@ class Ng2Block extends PdbBlock {
       'uri' => $component['path'],
       'element' => $machine_name,
     ];
+    $attached['drupalSettings']['pdb']['ng2']['module_path'] = drupal_get_path('module', 'pdb_ng2');
 
     return $attached;
   }


### PR DESCRIPTION
To define proper url to **Angular2** module, I defined "**module_path**" within _drupalSettings_ based on current path's module, I used the following method inside "**Ng2Block**" class:
`public function attachSettings(array $component)`

Also I setup proper URL to "**_ng2_todo_**" template and style files by "_drupalSettings_",
`drupalSettings.pdb.ng2.module_path`

Related with issue: #60 
