### PR TITLE
Show components only from enabled modules.

### DIFF
--- a/src/ComponentDiscovery.php
+++ b/src/ComponentDiscovery.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\pdb;
 
+use Drupal\Core\Extension\Extension;
 use Drupal\Core\Extension\ExtensionDiscovery;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -61,14 +62,40 @@ class ComponentDiscovery extends ExtensionDiscovery implements ComponentDiscover
 
     // Read info files for each module.
     foreach ($components as $key => $component) {
-      // Look for the info file.
-      $component->info = $this->infoParser->parse($component->getPathname());
-      // Merge in defaults and save.
-      $components[$key]->info = $component->info + $defaults;
+      if ($this->moduleIsEnabled($component)) {
+        // Look for the info file.
+        $component->info = $this->infoParser->parse($component->getPathname());
+        // Merge in defaults and save.
+        $components[$key]->info = $component->info + $defaults;
+      }
+      else {
+        // Don't show components from disabled modules.
+        unset($components[$key]);
+      }
     }
     $this->moduleHandler->alter('component_info', $components);
 
     return $components;
+  }
+
+  /**
+   * Check if component's module is enabled.
+   *
+   * @param \Drupal\Core\Extension\Extension $component
+   *   Component object.
+   *
+   * @return bool|null
+   *   TRUE if module is enabled.
+   */
+  protected function moduleIsEnabled(Extension $component) {
+    /** @var \Drupal\Core\Extension\Extension $module */
+    // Load enabled modules and iterate.
+    foreach ($enabled_modules = $this->moduleHandler->getModuleList() as $module) {
+      // Match component and module using their paths.
+      if (strpos($component->getPath(), $module->getPath() . '/components/') !== FALSE) {
+        return TRUE;
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Out of the box the module shows components from disabled modules which clutters blocks listing page and confuses the user. `ComponentDiscovery.php` was modified to verify if component's module is enabled. 

Since component doesn't contain module info, verification is done based on component and module paths.