### PR TITLE
Added pdb_twig sub-module with support for twig components

### DIFF
--- a/modules/pdb_twig/components/twig_hello_world/twig-hello-world.css
+++ b/modules/pdb_twig/components/twig_hello_world/twig-hello-world.css
@@ -1,0 +1,4 @@
+.hello-world {
+  font-weight: bold;
+  color: green;
+}

--- a/modules/pdb_twig/components/twig_hello_world/twig-hello-world.html.twig
+++ b/modules/pdb_twig/components/twig_hello_world/twig-hello-world.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Component template for twig-hello-word component.
+ */
+#}
+
+<div class="hello-world">
+  <strong>Hello Word!</strong>
+</div>

--- a/modules/pdb_twig/components/twig_hello_world/twig_hello_world.info.yml
+++ b/modules/pdb_twig/components/twig_hello_world/twig_hello_world.info.yml
@@ -1,0 +1,15 @@
+name: Twig Hello World
+machine_name: twig-hello-world
+type: pdb
+description: 'Provides a hello world component'
+package: PDB Twig
+version: '0.1.0'
+core: '8.x'
+module_status: active
+presentation: twig
+theme:
+  template: twig-hello-world
+add_css:
+  header:
+    component:
+      'twig-hello-world.css': {}

--- a/modules/pdb_twig/components/twig_lazy_build/TwigLazyBuild.php
+++ b/modules/pdb_twig/components/twig_lazy_build/TwigLazyBuild.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\pdb_twig\twig_lazy_build;
+
+/**
+ * Provides custom build steps for thetwig-lazy-build twig block.
+ */
+class TwigLazyBuild {
+
+  public static function build($build) {
+    // Create the template variable to be lazy builded.
+    $build['#lazy'] = [
+      '#lazy_builder' => [static::class . '::lazyBuilder', []],
+      '#create_placeholder' => TRUE,
+    ];
+
+    return $build;
+  }
+
+  /**
+   * Lazy builder callback.
+   *
+   * This will be executed once "#lazy" variable is rendered in the template.
+   */
+  public static function lazyBuilder() {
+    // Add some sleep time to make it slow.
+    sleep(2);
+
+    // Here is the slow processing required by this block.
+    $build = [];
+    $build['#markup'] = t('This was slow!!');
+
+    return $build;
+  }
+
+}

--- a/modules/pdb_twig/components/twig_lazy_build/twig-lazy-build.html.twig
+++ b/modules/pdb_twig/components/twig_lazy_build/twig-lazy-build.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Component template for twig-lazy-build component.
+ */
+#}
+
+<p>This is fast!</p>
+
+<p>{{ lazy }}</p>

--- a/modules/pdb_twig/components/twig_lazy_build/twig_lazy_build.info.yml
+++ b/modules/pdb_twig/components/twig_lazy_build/twig_lazy_build.info.yml
@@ -1,0 +1,14 @@
+name: Twig Lazy Build
+machine_name: twig-lazy-build
+type: pdb
+description: 'Provides a twig-lazy-build component'
+package: PDB Twig
+version: '0.1.0'
+core: '8.x'
+module_status: active
+presentation: twig
+class: Drupal\pdb_twig\twig_lazy_build\TwigLazyBuild
+theme:
+  variables:
+    lazy: ''
+  template: twig-lazy-build

--- a/modules/pdb_twig/components/twig_node/TwigNode.php
+++ b/modules/pdb_twig/components/twig_node/TwigNode.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\pdb_twig\twig_node\TwigNode;
+
+/**
+ * Provides custom build steps for the twig-node twig block.
+ */
+class TwigNode {
+
+  public static function build($build, $config) {
+    // Related context node is available on the config.
+    // This requires to make the context available on main PdbBlock class.
+    $node = $config['contexts']['entity:node'];
+    $build['#title'] = $node['title'][0]['value'];
+
+    return $build;
+  }
+
+}

--- a/modules/pdb_twig/components/twig_node/twig-node.html.twig
+++ b/modules/pdb_twig/components/twig_node/twig-node.html.twig
@@ -1,0 +1,8 @@
+{#
+/**
+ * @file
+ * Component template for twig-node component.
+ */
+#}
+
+<h2>{{ title }}</h2>

--- a/modules/pdb_twig/components/twig_node/twig_node.info.yml
+++ b/modules/pdb_twig/components/twig_node/twig_node.info.yml
@@ -1,0 +1,16 @@
+name: Twig Node
+machine_name: twig-node
+type: pdb
+description: 'Provides a twig-node component'
+package: PDB Twig
+version: '0.1.0'
+core: '8.x'
+module_status: active
+presentation: twig
+contexts:
+  entity: node
+class: Drupal\pdb_twig\twig_node\TwigNode
+theme:
+  variables:
+    title: ''
+  template: twig-node

--- a/modules/pdb_twig/config/install/pdb_twig.settings.yml
+++ b/modules/pdb_twig/config/install/pdb_twig.settings.yml
@@ -1,0 +1,1 @@
+block_full: true

--- a/modules/pdb_twig/pdb_twig.info.yml
+++ b/modules/pdb_twig/pdb_twig.info.yml
@@ -1,0 +1,9 @@
+name: PDB Twig
+type: module
+description: Provides support for twig components over PDB system.
+package: PDB
+version: 8.x-1.0
+configure: pdb_twig.admin_pdb_twig
+core: 8.x
+dependencies:
+  - pdb

--- a/modules/pdb_twig/pdb_twig.links.menu.yml
+++ b/modules/pdb_twig/pdb_twig.links.menu.yml
@@ -1,0 +1,5 @@
+pdb_twig.admin_pdb_twig:
+  title: 'PDB Twig'
+  route_name: pdb_twig.admin_pdb_twig
+  description: 'Configure PDB Twig Settings.'
+  parent: system.admin_config_services

--- a/modules/pdb_twig/pdb_twig.links.task.yml
+++ b/modules/pdb_twig/pdb_twig.links.task.yml
@@ -1,0 +1,9 @@
+pdb_twig.admin_pdb_twig:
+  route_name: pdb_twig.admin_pdb_twig
+  base_route: pdb_twig.admin_pdb_twig
+  title: 'Settings'
+
+pdb_twig.admin_import_translations:
+  route_name: pdb_twig.admin_import_translations
+  base_route: pdb_twig.admin_pdb_twig
+  title: 'Import Translations'

--- a/modules/pdb_twig/pdb_twig.module
+++ b/modules/pdb_twig/pdb_twig.module
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * @file
+ * Code for the PDB Twig module.
+ */
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Block\BlockPluginInterface;
+
+/**
+ * Implements hook_theme().
+ *
+ * Provide theme definitions for each twig component that provides a theme.
+ */
+function pdb_twig_theme() {
+  $items = [];
+  $prefix = \Drupal\pdb_twig\Plugin\Block\TwigBlock::THEME_PREFIX;
+
+  $discovery = \Drupal::service('pdb.component_discovery');
+  $components = $discovery->getComponents();
+
+  foreach ($components as $component) {
+    if ($component->info['presentation'] !== 'twig') {
+      continue;
+    }
+
+    // Only create theme definition if theme is an existing array.
+    if (!isset($component->info['theme']) || !is_array($component->info['theme'])) {
+      continue;
+    }
+
+    $theme_default = [
+      'variables' => [],
+      'path' => $component->getPath(),
+    ];
+
+    $machine_name = $component->info['machine_name'];
+    $items[$prefix . $machine_name] = $component->info['theme'] + $theme_default;
+  }
+
+  // Define themes for blocks holding twig components.
+  $module_path = \Drupal::service('module_handler')->getModule('pdb_twig')->getPath();
+  $twig_block_defaults = [
+    'render element' => 'elements',
+    'path' => $module_path . '/templates/block',
+  ];
+
+  $items['twig_block'] = [
+    'template' => 'twig-block',
+  ] + $twig_block_defaults;
+
+  $items['twig_block_full'] = [
+    'template' => 'twig-block--full',
+  ] + $twig_block_defaults;
+
+  return $items;
+}
+
+/**
+ * Implements hook_locale_translation_projects_alter().
+ *
+ * Allows to discover twig components as translation capable projects.
+ */
+function pdb_twig_locale_translation_projects_alter(&$projects) {
+  $discovery = \Drupal::service('pdb_twig.component_translations_discovery');
+  $projects += $discovery->getComponentTranslations();
+}
+
+/**
+ * Impelements hook_block_view_twig_component_alter().
+ */
+function pdb_twig_block_view_twig_component_alter(array &$build, BlockPluginInterface $block) {
+  // Change the block build #theme to use own block template.
+  $block_full = \Drupal::config('pdb_twig.settings')->get('block_full');
+  $build['#theme'] = $block_full ? 'twig_block_full' : 'twig_block';
+}
+
+/**
+ * Prepares variables for twig_block templates.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - elements: An associative array containing the properties of the element.
+ *     Properties used: #block, #configuration, #children, #plugin_id.
+ */
+function template_preprocess_twig_block(&$variables) {
+  $variables['derivative_plugin_id'] = str_replace('_', '-', $variables['elements']['#derivative_plugin_id']);
+  $variables['content'] = $variables['elements']['content'];
+
+  // Create a valid HTML ID and make sure it is unique.
+  if (!empty($variables['elements']['#id'])) {
+    $variables['attributes']['id'] = Html::getUniqueId('block-' . $variables['elements']['#id']);
+  }
+}
+
+/**
+ * Prepares variables for twig_block_full templates.
+ *
+ * Copied from core/modules/block/block.module.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - elements: An associative array containing the properties of the element.
+ *     Properties used: #block, #configuration, #children, #plugin_id.
+ */
+function template_preprocess_twig_block_full(&$variables) {
+  $variables['configuration'] = $variables['elements']['#configuration'];
+  $variables['derivative_plugin_id'] = str_replace('_', '-', $variables['elements']['#derivative_plugin_id']);
+  $variables['label'] = !empty($variables['configuration']['label_display']) ? $variables['configuration']['label'] : '';
+  $variables['content'] = $variables['elements']['content'];
+  // A block's label is configuration: it is static. Allow dynamic labels to be
+  // set in the render array.
+  if (isset($variables['elements']['content']['#title']) && !empty($variables['configuration']['label_display'])) {
+    $variables['label'] = $variables['elements']['content']['#title'];
+  }
+
+  // Create a valid HTML ID and make sure it is unique.
+  if (!empty($variables['elements']['#id'])) {
+    $variables['attributes']['id'] = Html::getUniqueId('block-' . $variables['elements']['#id']);
+  }
+
+  // Proactively add aria-describedby if possible to improve accessibility.
+  if ($variables['label'] && isset($variables['attributes']['role'])) {
+    $variables['title_attributes']['id'] = Html::getUniqueId($variables['label']);
+    $variables['attributes']['aria-describedby'] = $variables['title_attributes']['id'];
+  }
+}

--- a/modules/pdb_twig/pdb_twig.routing.yml
+++ b/modules/pdb_twig/pdb_twig.routing.yml
@@ -1,0 +1,16 @@
+# Path admin/config/services/pdb will need to be defined on parent.
+pdb_twig.admin_pdb_twig:
+  path: '/admin/config/services/pdb/pdb_twig'
+  defaults:
+    _form: '\Drupal\pdb_twig\Form\TwigConfigForm'
+    _title: 'PDB Twig'
+  requirements:
+    _permission: 'access administration pages'
+
+pdb_twig.admin_import_translations:
+  path: '/admin/config/services/pdb/import'
+  defaults:
+    _form: '\Drupal\pdb_twig\Form\ImportTranslationsForm'
+    _title: 'Import Translations'
+  requirements:
+    _permission: 'access administration pages'

--- a/modules/pdb_twig/pdb_twig.services.yml
+++ b/modules/pdb_twig/pdb_twig.services.yml
@@ -1,0 +1,11 @@
+services:
+  pdb_twig.component_translations_discovery:
+    class: '\Drupal\pdb_twig\ComponentTranslationsDiscovery'
+    arguments:
+      - '@app.root'
+      - '@module_handler'
+      - '@info_parser'
+
+  pdb_twig.component_manager:
+    class: '\Drupal\pdb_twig\ComponentManager'
+    arguments: ['@plugin.manager.block']

--- a/modules/pdb_twig/src/ComponentManager.php
+++ b/modules/pdb_twig/src/ComponentManager.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\pdb_twig;
+
+use Drupal\Core\Block\BlockManagerInterface;
+
+/**
+ * Provides a service with support for twig components.
+ */
+class ComponentManager implements ComponentManagerInterface {
+
+  /**
+   * The block manager.
+   *
+   * @var \Drupal\Core\Block\BlockManagerInterface
+   */
+  protected $blockManager;
+
+  /**
+   * Build a ComponentManager object.
+   *
+   * @param \Drupal\Core\Block\BlockManagerInterface $block_manager
+   *   The block manager.
+   */
+  public function __construct(BlockManagerInterface $block_manager) {
+    $this->blockManager = $block_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build($component, array $config = [], $render_block = TRUE) {
+    $block_plugin = $this->blockManager->createInstance("twig_component:$component", $config);
+    $block_content = $block_plugin->build();
+
+    if ($render_block) {
+      // Always render with the base template, full is tricky to support here.
+      $block_build = [
+        '#theme' => 'twig_block',
+        '#id' => str_replace('_', '', $block_plugin->getDerivativeId()),
+        '#derivative_plugin_id' => $block_plugin->getDerivativeId(),
+        'content' => $block_content,
+      ];
+    }
+    else {
+      $block_build = $block_content;
+    }
+
+    return $block_build;
+  }
+
+}

--- a/modules/pdb_twig/src/ComponentManagerInterface.php
+++ b/modules/pdb_twig/src/ComponentManagerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\pdb_twig;
+
+/**
+ * Defines an interface for a component manager.
+ */
+interface ComponentManagerInterface {
+
+  /**
+   * Builds a twig component for rendering.
+   *
+   * @param string $component
+   *   The component identifier.
+   * @param array $config
+   *   The component config.
+   * @param bool $render_block
+   *   Flag to wrap component content in block template or not.
+   *
+   * @return array
+   *   The component build info.
+   */
+  public function build($component, array $config, $render_block);
+
+}

--- a/modules/pdb_twig/src/ComponentTranslationsDiscovery.php
+++ b/modules/pdb_twig/src/ComponentTranslationsDiscovery.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\pdb_twig;
+
+use Drupal\Core\Utility\ProjectInfo;
+use Drupal\pdb\ComponentDiscovery;
+
+/**
+ * Discovery service for twig component locale translations.
+ */
+class ComponentTranslationsDiscovery extends ComponentDiscovery implements ComponentTranslationsDiscoveryInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getComponentTranslations() {
+    $components = $this->getComponents();
+
+    // Get the components that provide locale translations.
+    // Follows locale module approach to discover translation projects.
+    // See locale_translation_project_list().
+    $projects = [];
+    $additional_whitelist = [
+      'interface translation project',
+      'interface translation server pattern',
+    ];
+
+    $this->moduleHandler->loadInclude('locale', 'compare.inc');
+    $component_data = _locale_translation_prepare_project_list($components, 'pdb');
+
+    $project_info = new ProjectInfo();
+    $project_info->processInfoList($projects, $component_data, 'pdb', TRUE, $additional_whitelist);
+
+    return $projects;
+  }
+
+}

--- a/modules/pdb_twig/src/ComponentTranslationsDiscoveryInterface.php
+++ b/modules/pdb_twig/src/ComponentTranslationsDiscoveryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\pdb_twig;
+
+/**
+ * Defines an interface for a discovery of component locale translations.
+ */
+interface ComponentTranslationsDiscoveryInterface {
+
+  /**
+   * Find all components providing translations.
+   *
+   * @return array
+   *   The components providing translations.
+   */
+  public function getComponentTranslations();
+
+}

--- a/modules/pdb_twig/src/Form/ImportTranslationsForm.php
+++ b/modules/pdb_twig/src/Form/ImportTranslationsForm.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\pdb_twig\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a form to import twig component translations.
+ */
+class ImportTranslationsForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'pdb_twig_import_translations';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['intro'] = [
+      '#markup' => $this->t('Import all available translations for Twig components.'),
+    ];
+
+    // After a string is translated via the UI, it is considered a custom
+    // translation and can not be overriden. This check allows that.
+    $form['overwrite_customized'] = [
+      '#title' => $this->t('Overwrite existing customized translations'),
+      '#description' => $this->t('This will override translated string via UI, use with caution.'),
+      '#type' => 'checkbox',
+    ];
+
+    $form['actions'] = ['#type' => 'actions'];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Import Translations'),
+      '#button_type' => 'primary',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Use custom service to only import components that provide translations.
+    $discovery = \Drupal::service('pdb_twig.component_translations_discovery');
+    $projects = array_keys($discovery->getComponentTranslations());
+
+    // This needs to be configurable on the form.
+    $langcodes = ['es'];
+
+    \Drupal::moduleHandler()->loadInclude('locale', 'fetch.inc');
+    $options = _locale_translation_default_update_options();
+    $options['overwrite_options']['customized'] = (bool) $form_state->getValue('overwrite_customized');
+
+    // Use the locale translation batch.
+    $batch = locale_translation_batch_update_build($projects, $langcodes, $options);
+
+    // Add a check operation as the second operation of the batch.
+    // This is required to re-import an already imported translation PO file.
+    array_unshift($batch['operations'], [[self::class, 'importTranslationsCheckFiles'], [$projects, $langcodes]]);
+
+    // Add a check operation at the beginning of the batch.
+    // This is required to discover new translation projects.
+    array_unshift($batch['operations'], [[self::class, 'importTranslationsCheckProjects'], []]);
+
+    // Add a refresh operation.
+    // This is required to make changes avialable without clearing the cache.
+    $batch['operations'][] = [[self::class, 'importTranslationsRefresh'], [$langcodes]];
+    batch_set($batch);
+  }
+
+  /**
+   * Batch operation that checks for translation projects.
+   *
+   * This makes possible to discover new projects providing translations.
+   *
+   * @param array $context
+   *   The batch context.
+   */
+  public static function importTranslationsCheckProjects(&$context) {
+    // Check for projects providing translations.
+    \Drupal::moduleHandler()->loadInclude('locale', 'compare.inc');
+    locale_translation_build_projects();
+  }
+
+  /**
+   * Batch operation that checks for projects translation PO files.
+   *
+   * This makes possible to re-import already imported PO files.
+   *
+   * @param array $projects
+   *   The project names (pdb twig components).
+   * @param array $langcodes
+   *   The language codes.
+   * @param array $context
+   *   The batch context.
+   */
+  public static function importTranslationsCheckFiles($projects, $langcodes, &$context) {
+    // Check if the given projects have new translations.
+    // The check is based on PO file last modified timestamp.
+    \Drupal::moduleHandler()->loadInclude('locale', 'compare.inc');
+    locale_translation_check_projects_local($projects, $langcodes);
+    \Drupal::state()->set('locale.translation_last_checked', REQUEST_TIME);
+  }
+
+  /**
+   * Batch operation that refreshes translations for given languages.
+   *
+   * This makes imported PO changes available without clearing the cache.
+   *
+   * @param array $langcodes
+   *   The language codes.
+   * @param array $context
+   *   The batch context.
+   */
+  public static function importTranslationsRefresh($langcodes, &$context) {
+    // Refresh all the locale translations and clear the translation caches.
+    _locale_refresh_translations($langcodes);
+  }
+
+}

--- a/modules/pdb_twig/src/Form/TwigConfigForm.php
+++ b/modules/pdb_twig/src/Form/TwigConfigForm.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\pdb_twig\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a form with Twig components config.
+ */
+class TwigConfigForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['pdb_twig.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'pdb_twig_config_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('pdb_twig.settings');
+
+    $form['block_full'] = array(
+      '#type' => 'checkbox',
+      '#title' => $this->t('Full Block'),
+      '#description' => $this->t('Render full blocks with contextual links.'),
+      '#default_value' => $config->get('block_full'),
+    );
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $config = \Drupal::service('config.factory')->getEditable('pdb_twig.settings');
+
+    $block_full = $form_state->getValue('block_full');
+    $config->set('block_full', $block_full);
+    $config->save();
+  }
+
+}

--- a/modules/pdb_twig/src/Plugin/Block/TwigBlock.php
+++ b/modules/pdb_twig/src/Plugin/Block/TwigBlock.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\pdb_twig\Plugin\Block;
+
+use Drupal\pdb\Plugin\Block\PdbBlock;
+
+/**
+ * Exposes a Twig component as a block.
+ *
+ * @Block(
+ *   id = "twig_component",
+ *   admin_label = @Translation("Twig component"),
+ *   deriver = "\Drupal\pdb_twig\Plugin\Derivative\TwigBlockDeriver"
+ * )
+ */
+class TwigBlock extends PdbBlock {
+
+  /**
+   * Provides safe namespacing for pdb twig themes.
+   */
+  const THEME_PREFIX = 'pdb_twig_';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = parent::build();
+
+    $info = $this->getComponentInfo();
+
+    if (isset($info['theme'])) {
+      if (is_array($info['theme'])) {
+        $theme = self::THEME_PREFIX . $info['theme']['template'];
+      }
+      else {
+        // This adds support to use existing themes.
+        $theme = $info['theme'];
+      }
+
+      $build['#theme'] = $theme;
+    }
+
+    if (isset($info['class'])) {
+      // This requires the class to be avialable under Psr-4.
+      // This can be done by using composer.json autoload.
+      // TODO: check if there is another way to support this.
+      $class = $info['class'];
+      $build = $class::build($build, $this->configuration);
+    }
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function attachLibraries(array $component) {
+    $parent_libraries = parent::attachLibraries($component);
+    // This is required because parent is not adding the "library" property.
+    // TODO: This might need to be fixed in the parent and its sub-modules.
+    $framework_libraries = [];
+
+    $libraries = array(
+      'library' => array_merge($parent_libraries, $framework_libraries),
+    );
+
+    return $libraries;
+  }
+
+}

--- a/modules/pdb_twig/src/Plugin/Context/TwigContextDefinition.php
+++ b/modules/pdb_twig/src/Plugin/Context/TwigContextDefinition.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\pdb_twig\Plugin\Context;
+
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Defines a class for a non-existing context definition.
+ *
+ * This context definition allows to hide twig components from UI.
+ * This might require to be controlled on PdbBlock level.
+ */
+class TwigContextDefinition extends ContextDefinition {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDataDefinition() {
+    // Some minimum data definition required by the consumer of the definition.
+    return DataDefinition::create('string');
+  }
+
+}

--- a/modules/pdb_twig/src/Plugin/Derivative/TwigBlockDeriver.php
+++ b/modules/pdb_twig/src/Plugin/Derivative/TwigBlockDeriver.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\pdb_twig\Plugin\Derivative;
+
+use Drupal\pdb_twig\Plugin\Context\TwigContextDefinition;
+use Drupal\pdb\Plugin\Derivative\PdbBlockDeriver;
+
+/**
+ * Derives block plugin definitions for Twig components.
+ */
+class TwigBlockDeriver extends PdbBlockDeriver {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition) {
+    $definitions = parent::getDerivativeDefinitions($base_plugin_definition);
+
+    $twig_definitions = array_filter($definitions, function(array $definition) {
+      $info = $definition['info'];
+      // Only keep components that belong to twig presentation.
+      $is_twig = $info['presentation'] === 'twig';
+
+      // Only keep components that are not disabled.
+      // This piece might need to be moved to parent deriver.
+      $is_disabled = isset($info['module_status']) ? $info['module_status'] === 'disabled' : FALSE;
+
+      return $is_twig && !$is_disabled;
+    });
+
+    // This works but Drupal is caching class namespaces with apcu and
+    // it starts to get some problems for some cases like moving components.
+    // $loader = \Drupal::service('class_loader');
+    // Clearing the apcu could be a solution but does not seem performant.
+    // apcu_clear_cache();
+
+    // Some extra stuff for twig components.
+    $components = $this->componentDiscovery->getComponents();
+    foreach ($twig_definitions as $block_id => $definition) {
+      $component = $components[$block_id];
+      // Add some support to hide the block on the UI.
+      // This piece might need to be moved to parent deriver.
+      // The block will be created but not listed on the block layout UI.
+      if ($component->info['module_status'] === 'hidden') {
+        $twig_definitions[$block_id]['_block_ui_hidden'] = TRUE;
+
+        // Create a non-existing context so the block will be hidden other UIs.
+        if (empty($this->derivatives[$block_id]['context'])) {
+          $twig_definitions[$block_id]['context'] = [];
+        }
+        $twig_definitions[$block_id]['context']['pdb_hidden'] = new TwigContextDefinition('pdb:hidden');
+      }
+
+      // Add the path to the component.
+      // This might require to go to parent deriver.
+      $component_path = $component->getPath();
+      $twig_definitions[$block_id]['info']['path'] = $component_path;
+
+      // Add the class to the Psr-4 namespaces.
+      // $loader->addPsr4('Drupal\\' . $block_id . '\\', \Drupal::root() . '/' . $component_path, TRUE, TRUE);
+    }
+
+    return $twig_definitions;
+  }
+
+}

--- a/modules/pdb_twig/templates/block/twig-block--full.html.twig
+++ b/modules/pdb_twig/templates/block/twig-block--full.html.twig
@@ -1,0 +1,40 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - derivative_plugin_id: The derivative ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_twig_block_full()
+ */
+#}
+
+<div{{ attributes }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  <{{ derivative_plugin_id }}>
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </{{ derivative_plugin_id }}>
+</div>

--- a/modules/pdb_twig/templates/block/twig-block.html.twig
+++ b/modules/pdb_twig/templates/block/twig-block.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - derivative_plugin_id: The ID of the block implementation.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ *
+ * @see template_preprocess_twig_block()
+ */
+#}
+
+<{{ derivative_plugin_id }} {{ attributes }}>
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</{{ derivative_plugin_id }}>


### PR DESCRIPTION
This provides a new sub-module pdb_twig that adds support to create components for a new type of presentation named `twig`. This use built-in Drupal stuff (php + twig) to create decoupled blocks based on the PDB system.