### PR TITLE
Module pdb_twig updates

### DIFF
--- a/modules/pdb_twig/pdb_twig.module
+++ b/modules/pdb_twig/pdb_twig.module
@@ -70,7 +70,14 @@ function pdb_twig_locale_translation_projects_alter(&$projects) {
 /**
  * Impelements hook_block_view_twig_component_alter().
  */
-function pdb_twig_block_view_twig_component_alter(array &$build, BlockPluginInterface $block) {
+function cs_pdb_twig_block_view_twig_component_alter(array &$build, BlockPluginInterface $block) {
+  // Consider a block has no content if only has content and #cache keys.
+  $build_content = array_diff(array_keys($build), ['content', '#cache']);
+  if (empty($build_content)) {
+    return;
+  }
+
+  // Only add the custom theme implementation if block is not empty.
   // Change the block build #theme to use own block template.
   $block_full = \Drupal::config('pdb_twig.settings')->get('block_full');
   $build['#theme'] = $block_full ? 'twig_block_full' : 'twig_block';

--- a/modules/pdb_twig/pdb_twig.services.yml
+++ b/modules/pdb_twig/pdb_twig.services.yml
@@ -8,4 +8,4 @@ services:
 
   pdb_twig.component_manager:
     class: '\Drupal\pdb_twig\ComponentManager'
-    arguments: ['@plugin.manager.block']
+    arguments: ['@plugin.manager.block', '@request_stack']

--- a/modules/pdb_twig/src/ComponentManager.php
+++ b/modules/pdb_twig/src/ComponentManager.php
@@ -3,6 +3,8 @@
 namespace Drupal\pdb_twig;
 
 use Drupal\Core\Block\BlockManagerInterface;
+use Drupal\Core\Plugin\Context\Context;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides a service with support for twig components.
@@ -17,13 +19,30 @@ class ComponentManager implements ComponentManagerInterface {
   protected $blockManager;
 
   /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The contexts required by plugins being built.
+   *
+   * @var array
+   */
+  protected $contexts = [];
+
+  /**
    * Build a ComponentManager object.
    *
    * @param \Drupal\Core\Block\BlockManagerInterface $block_manager
    *   The block manager.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
    */
-  public function __construct(BlockManagerInterface $block_manager) {
+  public function __construct(BlockManagerInterface $block_manager, RequestStack $request_stack) {
     $this->blockManager = $block_manager;
+    $this->requestStack = $request_stack;
   }
 
   /**
@@ -31,6 +50,29 @@ class ComponentManager implements ComponentManagerInterface {
    */
   public function build($component, array $config = [], $render_block = TRUE) {
     $block_plugin = $this->blockManager->createInstance("twig_component:$component", $config);
+
+    // Check and build block required contexts.
+    $context_defs = $block_plugin->getContextDefinitions();
+    if ($context_defs) {
+      $request = $this->requestStack->getCurrentRequest();
+
+      foreach ($context_defs as $context_key => $context_def) {
+        // Do not process pdb:hidden context definitions.
+        if ($context_def->getDataType() === 'pdb:hidden') {
+          continue;
+        }
+
+        if (!isset($this->contexts[$context_key])) {
+          $context_name = $context_def->getDataDefinition()->getEntityTypeId();
+          if ($request->attributes->has($context_name)) {
+            $value = $request->attributes->get($context_name);
+          }
+          $this->contexts[$context_key] = new Context($context_def, $value);
+        }
+      }
+      \Drupal::service('context.handler')->applyContextMapping($block_plugin, $this->contexts);
+    }
+
     $block_content = $block_plugin->build();
 
     if ($render_block) {

--- a/modules/pdb_twig/src/Plugin/Block/TwigBlock.php
+++ b/modules/pdb_twig/src/Plugin/Block/TwigBlock.php
@@ -27,6 +27,20 @@ class TwigBlock extends PdbBlock {
     $build = parent::build();
 
     $info = $this->getComponentInfo();
+    $machine_name = $info['machine_name'];
+
+    if (isset($info['class'])) {
+      // This requires the class to be avialable under Psr-4.
+      // This can be done by using composer.json autoload.
+      // TODO: check if there is another way to support this.
+      $class = $info['class'];
+      $build = $class::build($build, $this->configuration);
+
+      // Allow a block do not render by returning an empty array.
+      if (empty($build)) {
+        return [];
+      }
+    }
 
     if (isset($info['theme'])) {
       if (is_array($info['theme'])) {
@@ -38,14 +52,6 @@ class TwigBlock extends PdbBlock {
       }
 
       $build['#theme'] = $theme;
-    }
-
-    if (isset($info['class'])) {
-      // This requires the class to be avialable under Psr-4.
-      // This can be done by using composer.json autoload.
-      // TODO: check if there is another way to support this.
-      $class = $info['class'];
-      $build = $class::build($build, $this->configuration);
     }
 
     return $build;

--- a/modules/pdb_twig/src/Plugin/Derivative/TwigBlockDeriver.php
+++ b/modules/pdb_twig/src/Plugin/Derivative/TwigBlockDeriver.php
@@ -48,7 +48,11 @@ class TwigBlockDeriver extends PdbBlockDeriver {
         if (empty($this->derivatives[$block_id]['context'])) {
           $twig_definitions[$block_id]['context'] = [];
         }
-        $twig_definitions[$block_id]['context']['pdb_hidden'] = new TwigContextDefinition('pdb:hidden');
+        $context_def = new TwigContextDefinition('pdb:hidden');
+        // Set a defualt value so it will not fail when creating instances
+        // with the component manager service.
+        $context_def->setDefaultValue('hidden');
+        $twig_definitions[$block_id]['context']['pdb_hidden'] = $context_def;
       }
 
       // Add the path to the component.


### PR DESCRIPTION
Provides the following updates:
* When building a component using the component manager service, builds the component required contexts to make them available to the component.
* Added a default value for the pdb:hidden context assigned to hidden components on the block deriver.
* Properly handles the return value of empty blocks so they do not render on the page.