### PR TITLE
Made usage of component package as block category on pdb main deriver

### DIFF
--- a/src/ComponentDiscovery.php
+++ b/src/ComponentDiscovery.php
@@ -55,7 +55,6 @@ class ComponentDiscovery extends ExtensionDiscovery implements ComponentDiscover
     $defaults = array(
       'dependencies' => array(),
       'description' => '',
-      'package' => 'Other',
       'version' => NULL,
     );
 

--- a/src/Plugin/Derivative/PdbBlockDeriver.php
+++ b/src/Plugin/Derivative/PdbBlockDeriver.php
@@ -50,6 +50,12 @@ class PdbBlockDeriver extends DeriverBase implements ContainerDeriverInterface {
       $this->derivatives[$block_id]['info'] = $block_info->info;
       $this->derivatives[$block_id]['admin_label'] = $block_info->info['name'];
       $this->derivatives[$block_id]['cache'] = array('max-age' => 0);
+
+      // Only set category if package is set, defaults to provider if not.
+      if (isset($block_info->info['package'])){
+        $this->derivatives[$block_id]['category'] =$block_info->info['package'];
+      }
+
       if (isset($block_info->info['contexts'])) {
         $this->derivatives[$block_id]['context'] = $this->createContexts($block_info->info['contexts']);
       }


### PR DESCRIPTION
The component info package property was not used to categorize the Drupal blocks on the UI. This makes use of the package property to set the block category property that allows to categorize the blocks on the UI.