### PR TITLE
Updated pdb_react main library to load before react component libraries

### DIFF
--- a/modules/pdb_react/pdb_react.libraries.yml
+++ b/modules/pdb_react/pdb_react.libraries.yml
@@ -1,8 +1,14 @@
 react:
   version: VERSION
   js:
-    //cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react.min.js: {type: external, minified: true}
-    //cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react-dom.min.js: {type: external, minified: true}
+    //cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react.min.js:
+      type: external
+      minified: true
+      weight: -10
+    //cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react-dom.min.js:
+      type: external
+      minified: true
+      weight: -10
   dependencies:
     - core/drupal
     - core/drupalSettings


### PR DESCRIPTION
By default, component libraries defined as part of the component are being included in the page before the main react library. There is a dependency restriction added in the main pdb.module to require to load the main react library and fix that issue. Though, this is also applying to other presentations like ng2 and newer twig one, throwing errors since libraries like `pdb_ng2/ng2` do not exist. So this is a required fix prior to deprecate that library restriction that basically gives a lower weight and thus making the main library being included before the component ones.