### PR TITLE
Removed component libraries dependency with supposed presentation library

### DIFF
--- a/pdb.module
+++ b/pdb.module
@@ -52,17 +52,11 @@ function pdb_library_info_build() {
     // Build a library to include assets in header.
     if (!empty($library_header)) {
       $library_header['header'] = TRUE;
-      // Add dependency on presentation library.
-      $pres = $info['presentation'];
-      $library_header['dependencies'] = array('pdb_' . $pres . '/' . $pres);
       $libraries += [$info['machine_name'] . '/header' => $library_header];
     }
 
     // Build a library to include assets in footer.
     if (!empty($library_footer)) {
-      // Add dependency on presentation library.
-      $pres = $info['presentation'];
-      $library_footer['dependencies'] = array('pdb_' . $pres . '/' . $pres);
       $libraries += [$info['machine_name'] . '/footer' => $library_footer];
     }
   }


### PR DESCRIPTION
This removes a hard dependency requirement for component libraries. This supposes that a presentation library like `pdb_ng2/ng2` exists and provides main library definitions for the presentation. This helps on making the presentation library to be loaded before the components one but right now is only being used by `pdb_react` and throwing errors because `pdb_ng2` and newer `pdb_twig` does not define one. We could fix this by implementing an "empty" library (`pdb_ng2` defines one and we could maybe change the name of that to match `pdb_ng2/ng2` one) but this same requirement would apply to future presentations. So instead, we can make library definition to have a lower weight and be loaded before components one. See #112.