### PR TITLE
Removed cache max-age definition on main block deriver

### DIFF
--- a/src/Plugin/Derivative/PdbBlockDeriver.php
+++ b/src/Plugin/Derivative/PdbBlockDeriver.php
@@ -49,7 +49,6 @@ class PdbBlockDeriver extends DeriverBase implements ContainerDeriverInterface {
       $this->derivatives[$block_id] = $base_plugin_definition;
       $this->derivatives[$block_id]['info'] = $block_info->info;
       $this->derivatives[$block_id]['admin_label'] = $block_info->info['name'];
-      $this->derivatives[$block_id]['cache'] = array('max-age' => 0);
       if (isset($block_info->info['contexts'])) {
         $this->derivatives[$block_id]['context'] = $this->createContexts($block_info->info['contexts']);
       }


### PR DESCRIPTION
This is removing a hard limitation added to the main block deriver. Dont see a real reason to try to disable cache for all blocks derived by the main deriver. Also, could not actually see this working on my tests. Instead of making this for all presentations, we can accomplish this by, I think the correct way, implementing the `getCacheMaxAge` method on the block Class for the presentation that do actually need and require to completely disable the cache for its components.