### PR TITLE
Added support for add dependencies to component library build

### DIFF
--- a/pdb.module
+++ b/pdb.module
@@ -49,6 +49,25 @@ function pdb_library_info_build() {
       }
     }
 
+    if (isset($info['add_dependencies'])) {
+      // This can not support libraries that only require dependencies but do
+      // not add any css or js asset because a core limitation.
+      // See https://www.drupal.org/project/drupal/issues/2905429.
+      if (isset($info['add_dependencies']['header']) && !empty($library_header)) {
+        $library_header['dependencies'] = [];
+        foreach ($info['add_dependencies']['header'] as $library) {
+          $library_header['dependencies'][] = $library;
+        }
+      }
+
+      if (isset($info['add_dependencies']['footer']) && !empty($library_footer)) {
+        $library_footer['dependencies'] = [];
+        foreach ($info['add_dependencies']['footer'] as $library) {
+          $library_footer['dependencies'][] = $library;
+        }
+      }
+    }
+
     // Build a library to include assets in header.
     if (!empty($library_header)) {
       $library_header['header'] = TRUE;


### PR DESCRIPTION
This allows to define dependency with other libraries on the component info file.
Use the following pattern on the info file of the component:

Add a library dependency that will be a dependency for the component header library.
```
add_dependencies:
  header:
    - core/drupal.ajax
```

Add a library dependency that will be a dependency for the component footer library.
```
add_dependencies:
  footer:
    - core/drupal.ajax
```