### PR TITLE
Component path available at component info array for plugin blocks

### DIFF
--- a/modules/pdb_ng2/pdb_ng2.module
+++ b/modules/pdb_ng2/pdb_ng2.module
@@ -4,32 +4,3 @@
  * @file
  * Any procedural Angular 2 PHP work lives here.
  */
-
-
-/**
- * Add our component paths for Angular 2.
- *
- * @param object $components
- */
-function pdb_ng2_component_info_alter($components) {
-  // Read info files for each module.
-  foreach ($components as $key => $component) {
-    // Set component path if it hasn't been hardcoded.
-    if ($component->info['presentation'] == 'ng2' && empty($component->info['path'])) {
-      // Use js or ts sourcing depending on development mode.
-      $config_settings = \Drupal::config('pdb_ng2.settings');
-      $ext = 'js';
-      if (isset($config_settings) && $config_settings->get('development_mode')) {
-        $ext = 'ts';
-      }
-      $component->info['path'] = $component->getPath();
-    }
-    else {
-      $path = isset($component->info['path']) ? $component->info['path'] : '';
-      if ($path{0} != '/') {
-        $component->info['path'] = $component->getPath() . '/' . $path;
-      }
-    }
-
-  }
-}

--- a/src/ComponentDiscovery.php
+++ b/src/ComponentDiscovery.php
@@ -91,6 +91,9 @@ class ComponentDiscovery extends ExtensionDiscovery implements ComponentDiscover
     foreach ($components as $key => $component) {
       // Look for the info file.
       $component->info = $this->infoParser->parse($component->getPathname());
+      // Make component path available for block plugins (eg. ReactBlock).
+      $component->info['path'] = $component->getPath();
+
       // Merge in defaults and save.
       $components[$key]->info = $component->info + $defaults;
     }


### PR DESCRIPTION
Some plugin blocks like `ReactBlock` or `Ng2Block` require the path to the component to work.
There is code on `pdb_ng2` that is taking care of the component path when it is not available. Don't know why but it seems that something changed on recent core versions and this code is not working properly for components other than ng2. Also, taking care of other presentation stuff on `pdb_ng2` can be confusing.
This PR is then making the path available at component info array on component discovery for plugin blocks that require it. With that, the code on `pdb_ng2.module` is deprecated now and thus removed.