### PR TITLE
Component context creation and handling update

### DIFF
--- a/modules/pdb_twig/components/twig_node/TwigNode.php
+++ b/modules/pdb_twig/components/twig_node/TwigNode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\pdb_twig\twig_node\TwigNode;
+namespace Drupal\pdb_twig\twig_node;
 
 /**
  * Provides custom build steps for the twig-node twig block.
@@ -9,9 +9,8 @@ class TwigNode {
 
   public static function build($build, $config) {
     // Related context node is available on the config.
-    // This requires to make the context available on main PdbBlock class.
     $node = $config['contexts']['entity:node'];
-    $build['#title'] = $node['title'][0]['value'];
+    $build['#title'] = $node->getTitle();
 
     return $build;
   }

--- a/src/Plugin/Derivative/PdbBlockDeriver.php
+++ b/src/Plugin/Derivative/PdbBlockDeriver.php
@@ -71,16 +71,21 @@ class PdbBlockDeriver extends DeriverBase implements ContainerDeriverInterface {
    *
    * @return \Drupal\Core\Plugin\Context\ContextDefinition[]
    *   Array of context to be used by block module
-   *
-   * @todo where is this defined in block module
    */
   protected function createContexts(array $contexts) {
     $contexts_definitions = [];
-    if (isset($contexts['entity'])) {
-      // @todo Check entity type exists and fail!
-      $contexts_definitions['entity'] = new ContextDefinition('entity:' . $contexts['entity']);
+
+    // Support for old node entity context defintion.
+    // "entity: node" should now be defined "entity: entity:node".
+    if (isset($contexts['entity']) && $contexts['entity'] === 'node') {
+      // For some reason even if context_id is "node" it must be set "entity".
+      $contexts['entity'] = 'entity:node';
     }
-    // @todo Dynamically handle unknown context definitions
+
+    foreach ($contexts as $context_id => $context_type) {
+      $contexts_definitions[$context_id] = new ContextDefinition($context_type);
+    }
+
     return $contexts_definitions;
   }
 


### PR DESCRIPTION
This updates the context creation on the block plugin deriver. More types of contexts can be used now.
This also updates the context value handling on the block plugin build step. Before serialize the context value to send to front-end, the context value is stored as part of the block configuration so other presentation (for now only `pdb_twig`) can make use of the original context value (specially when it is an entity like a node) to process and get data from it.